### PR TITLE
Strings should not be thrown directly

### DIFF
--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -27,7 +27,7 @@ foreign import message
 foreign import throwException 
   "function throwException(e) {\
   \  return function() {\
-  \    throw e;\
+  \    throw new Error(e);\
   \  };\
   \}" :: forall a eff. Error -> Eff (err :: Exception | eff) a
 


### PR DESCRIPTION
Most js code is expecting a full Error object not a string. Throwing strings directly is not considered to be a good practice overall. 
