### PR TITLE
Docs, exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,79 @@
 
 ## Module Control.Monad.Eff.Exception
 
-### Types
 
-    data Error :: *
+This module defines an effect, actions and handlers for working
+with Javascript exceptions.
 
-    data Exception :: !
+#### `Exception`
+
+``` purescript
+data Exception :: !
+```
+
+This effect is used to annotate code which possibly throws exceptions
+
+#### `Error`
+
+``` purescript
+data Error :: *
+```
+
+The type of Javascript errors
+
+#### `showError`
+
+``` purescript
+instance showError :: Show Error
+```
 
 
-### Type Class Instances
+#### `error`
 
-    instance showError :: Show Error
+``` purescript
+error :: String -> Error
+```
 
+Create a Javascript error, specifying a message
 
-### Values
+#### `message`
 
-    catchException :: forall a eff. (Error -> Eff eff a) -> Eff (err :: Exception | eff) a -> Eff eff a
+``` purescript
+message :: Error -> String
+```
 
-    error :: String -> Error
+Get the error message from a Javascript error
 
-    message :: Error -> String
+#### `throwException`
 
-    showErrorImpl :: Error -> String
+``` purescript
+throwException :: forall a eff. Error -> Eff (err :: Exception | eff) a
+```
 
-    throwException :: forall a eff. Error -> Eff (err :: Exception | eff) a
+Throw an exception
+
+For example:
+
+```purescript
+main = do
+  x <- readNumber
+  when (x < 0) $ throwException $ 
+    error "Expected a non-negative number"
+```
+
+#### `catchException`
+
+``` purescript
+catchException :: forall a eff. (Error -> Eff eff a) -> Eff (err :: Exception | eff) a -> Eff eff a
+```
+
+Catch an exception by providing an exception handler.
+
+This handler removes the `Exception` effect.
+
+For example:
+
+```purescript
+main = catchException print do
+  trace "Exceptions thrown in this block will be logged to the console"
+```

--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -1,9 +1,21 @@
-module Control.Monad.Eff.Exception where
+-- | This module defines an effect, actions and handlers for working
+-- | with Javascript exceptions.
+
+module Control.Monad.Eff.Exception 
+  ( Exception()
+  , Error()
+  , error
+  , message
+  , throwException
+  , catchException
+  ) where
 
 import Control.Monad.Eff
 
+-- | This effect is used to annotate code which possibly throws exceptions
 foreign import data Exception :: !
 
+-- | The type of Javascript errors
 foreign import data Error :: *
 
 instance showError :: Show Error where
@@ -16,6 +28,7 @@ foreign import showErrorImpl
   }
   """ :: Error -> String
 
+-- | Create a Javascript error, specifying a message
 foreign import error
   """
   function error(msg) {
@@ -23,6 +36,7 @@ foreign import error
   }
   """ :: String -> Error
 
+-- | Get the error message from a Javascript error
 foreign import message
   """
   function message(e) {
@@ -30,6 +44,16 @@ foreign import message
   }
   """ :: Error -> String
 
+-- | Throw an exception
+-- |
+-- | For example:
+-- |
+-- | ```purescript
+-- | main = do
+-- |   x <- readNumber
+-- |   when (x < 0) $ throwException $ 
+-- |     error "Expected a non-negative number"
+-- | ```
 foreign import throwException
   """
   function throwException(e) {
@@ -39,6 +63,16 @@ foreign import throwException
   }
   """ :: forall a eff. Error -> Eff (err :: Exception | eff) a
 
+-- | Catch an exception by providing an exception handler.
+-- |
+-- | This handler removes the `Exception` effect.
+-- |
+-- | For example:
+-- |
+-- | ```purescript
+-- | main = catchException print do
+-- |   trace "Exceptions thrown in this block will be logged to the console"
+-- | ```
 foreign import catchException
   """
   function catchException(c) {


### PR DESCRIPTION
@garyb Could you please review?

I added an export list which hides `showErrorImpl`, so this is technically a breaking change, but I very much doubt anyone uses that function.