### PR TITLE
Add unsafeThrowException and unsafeThrow

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-eff": "^0.1.0"
+    "purescript-eff": "^0.1.2"
   }
 }

--- a/docs/Control/Monad/Eff/Exception/Unsafe.md
+++ b/docs/Control/Monad/Eff/Exception/Unsafe.md
@@ -1,0 +1,20 @@
+## Module Control.Monad.Eff.Exception.Unsafe
+
+#### `unsafeThrowException`
+
+``` purescript
+unsafeThrowException :: forall a. Error -> a
+```
+
+Throw an exception in pure code. This function should be used very
+sparingly, as it can cause unexpected crashes at runtime.
+
+#### `unsafeThrow`
+
+``` purescript
+unsafeThrow :: forall a. String -> a
+```
+
+Defined as `unsafeThrowException <<< error`.
+
+

--- a/src/Control/Monad/Eff/Exception/Unsafe.purs
+++ b/src/Control/Monad/Eff/Exception/Unsafe.purs
@@ -1,0 +1,18 @@
+module Control.Monad.Eff.Exception.Unsafe where
+
+import Prelude
+import Control.Monad.Eff
+import Control.Monad.Eff.Unsafe
+import Control.Monad.Eff.Exception
+
+-- | Throw an exception in pure code. This function should be used very
+-- | sparingly, as it can cause unexpected crashes at runtime.
+unsafeThrowException :: forall a. Error -> a
+unsafeThrowException = unsafeRunEff <<< throwException
+  where
+  unsafeRunEff :: forall e b. Eff e b -> b
+  unsafeRunEff = runPure <<< unsafeInterleaveEff
+
+-- | Defined as `unsafeThrowException <<< error`.
+unsafeThrow :: forall a. String -> a
+unsafeThrow = unsafeThrowException <<< error

--- a/src/Control/Monad/Eff/Exception/Unsafe.purs
+++ b/src/Control/Monad/Eff/Exception/Unsafe.purs
@@ -8,10 +8,7 @@ import Control.Monad.Eff.Exception
 -- | Throw an exception in pure code. This function should be used very
 -- | sparingly, as it can cause unexpected crashes at runtime.
 unsafeThrowException :: forall a. Error -> a
-unsafeThrowException = unsafeRunEff <<< throwException
-  where
-  unsafeRunEff :: forall e b. Eff e b -> b
-  unsafeRunEff = runPure <<< unsafeInterleaveEff
+unsafeThrowException = unsafePerformEff <<< throwException
 
 -- | Defined as `unsafeThrowException <<< error`.
 unsafeThrow :: forall a. String -> a


### PR DESCRIPTION
For writing partial functions without having to resort to the FFI. For example, functions like `Data.Maybe.Unsafe.fromJust`