### PR TITLE
Remove unused import

### DIFF
--- a/src/Control/Monad/Eff/Exception/Unsafe.purs
+++ b/src/Control/Monad/Eff/Exception/Unsafe.purs
@@ -1,7 +1,6 @@
 module Control.Monad.Eff.Exception.Unsafe where
 
 import Prelude
-import Control.Monad.Eff
 import Control.Monad.Eff.Unsafe
 import Control.Monad.Eff.Exception
 


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.