### PR TITLE
rethrow: throw a new, modified version of an exception

### DIFF
--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -9,6 +9,7 @@ module Control.Monad.Eff.Exception
   , stack
   , throwException
   , catchException
+  , rethrowException
   , throw
   , try
   ) where
@@ -16,6 +17,7 @@ module Control.Monad.Eff.Exception
 import Prelude
 
 import Control.Monad.Eff (Eff, kind Effect)
+import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -77,6 +79,11 @@ foreign import catchException
    . (Error -> Eff eff a)
   -> Eff (exception :: EXCEPTION | eff) a
   -> Eff eff a
+
+-- | Catch an exception and throw a new one.
+rethrowException :: forall a eff. (Error -> Error) -> Eff (exception :: EXCEPTION | eff) a -> Eff (exception :: EXCEPTION | eff) a
+rethrowException errFn =
+  catchException (throwException <<< errFn) <<< unsafeCoerceEff
 
 -- | A shortcut allowing you to throw an error in one step. Defined as
 -- | `throwException <<< error`.

--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -81,7 +81,7 @@ foreign import catchException
   -> Eff eff a
 
 -- | Catch an exception and throw a new one.
-rethrowException :: forall a eff. (Error -> Error) -> Eff (exception :: EXCEPTION | eff) a -> Eff (exception :: EXCEPTION | eff) a
+rethrowException :: forall eff. (Error -> Error) -> Eff (exception :: EXCEPTION | eff) ~> Eff (exception :: EXCEPTION | eff)
 rethrowException errFn =
   catchException (throwException <<< errFn) <<< unsafeCoerceEff
 

--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -80,7 +80,7 @@ foreign import catchException
   -> Eff (exception :: EXCEPTION | eff) a
   -> Eff eff a
 
--- | Catch an exception and throw a new one.
+-- | If an exception is thrown, catch it and throw a new one.
 rethrowException :: forall eff. (Error -> Error) -> Eff (exception :: EXCEPTION | eff) ~> Eff (exception :: EXCEPTION | eff)
 rethrowException errFn =
   catchException (throwException <<< errFn) <<< unsafeCoerceEff


### PR DESCRIPTION
It seems quite important to have something like this, which I was sadly unable to achieve without cheating the type system a bit.

If someone knows of a way to kill off the coercion, I'd be very happy to do so!