### PR TITLE
add getter for error's name when available

### DIFF
--- a/src/Control/Monad/Eff/Exception.js
+++ b/src/Control/Monad/Eff/Exception.js
@@ -12,6 +12,10 @@ exports.message = function (e) {
   return e.message;
 };
 
+exports.name = function (e) {
+  return e.name || "Error";
+};
+
 exports.stackImpl = function (just) {
   return function (nothing) {
     return function (e) {

--- a/src/Control/Monad/Eff/Exception.purs
+++ b/src/Control/Monad/Eff/Exception.purs
@@ -6,6 +6,7 @@ module Control.Monad.Eff.Exception
   , Error
   , error
   , message
+  , name
   , stack
   , throwException
   , catchException
@@ -36,6 +37,9 @@ foreign import error :: String -> Error
 
 -- | Get the error message from a JavaScript error
 foreign import message :: Error -> String
+
+-- | Get the error name when defined, or fallback to 'Error'
+foreign import name :: Error -> String
 
 -- | Get the stack trace from a JavaScript error
 stack :: Error -> Maybe String


### PR DESCRIPTION
Hi folks!

I've added a small accessor which retrieves the `name` of an error when available. The property is specified by the [ECMAScript spec 5.1](http://www.ecma-international.org/ecma-262/5.1/#sec-15.11) and is quite useful to perform pattern matching in a relatively reliable way.

In some cases and for some browsers though, the property `name` remains undefined in which case I chose to fallback to the initial name of 'Error' (instead of going for a `Error -> Maybe String` as I find the former approach more practical).

Let me know :+1: 