### PR TITLE
Add errorWithCause constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
-- Add `errorWithCause`
+- Add `errorWithCause` (#43 by @sigma-andex)
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `errorWithCause`
 
 Bugfixes:
 

--- a/src/Effect/Exception.js
+++ b/src/Effect/Exception.js
@@ -9,7 +9,7 @@ export function error(msg) {
 export function errorWithCause(msg) {
   return function(cause) {
     return new Error(msg, { cause });
-  }
+  };
 }
 
 export function message(e) {

--- a/src/Effect/Exception.js
+++ b/src/Effect/Exception.js
@@ -6,6 +6,12 @@ export function error(msg) {
   return new Error(msg);
 }
 
+export function errorWithCause(msg) {
+  return function(cause) {
+    return new Error(msg, { cause });
+  }
+}
+
 export function message(e) {
   return e.message;
 }

--- a/src/Effect/Exception.purs
+++ b/src/Effect/Exception.purs
@@ -3,15 +3,17 @@
 
 module Effect.Exception
   ( Error
+  , catchException
   , error
+  , errorWithCause
   , message
   , name
   , stack
-  , throwException
-  , catchException
   , throw
+  , throwException
   , try
-  ) where
+  )
+  where
 
 import Prelude
 
@@ -30,6 +32,9 @@ foreign import showErrorImpl :: Error -> String
 
 -- | Create a JavaScript error, specifying a message
 foreign import error :: String -> Error
+
+-- | Create a JavaScript error, specifying a message and a cause
+foreign import errorWithCause :: String -> Error -> Error
 
 -- | Get the error message from a JavaScript error
 foreign import message :: Error -> String


### PR DESCRIPTION
**Description of the change**

Add `errorWithCause` constructor for creating `Error`s with a cause.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#rethrowing_an_error_with_a_cause

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
