### PR TITLE
Add errorWithName constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 New features:
 - Add `errorWithCause` (#43 by @sigma-andex)
+- Add `errorWithName` (#44 by @jedimahdi)
 
 Bugfixes:
 

--- a/src/Effect/Exception.js
+++ b/src/Effect/Exception.js
@@ -12,6 +12,14 @@ export function errorWithCause(msg) {
   };
 }
 
+export function errorWithName(msg) {
+  return function(name) {
+    const e = new Error(msg);
+    e.name = name;
+    return e;
+  };
+}
+
 export function message(e) {
   return e.message;
 }

--- a/src/Effect/Exception.purs
+++ b/src/Effect/Exception.purs
@@ -6,6 +6,7 @@ module Effect.Exception
   , catchException
   , error
   , errorWithCause
+  , errorWithName
   , message
   , name
   , stack
@@ -35,6 +36,9 @@ foreign import error :: String -> Error
 
 -- | Create a JavaScript error, specifying a message and a cause
 foreign import errorWithCause :: String -> Error -> Error
+
+-- | Create a JavaScript error, specifying a message and a name
+foreign import errorWithName :: String -> String -> Error
 
 -- | Get the error message from a JavaScript error
 foreign import message :: Error -> String


### PR DESCRIPTION
**Description of the change**

Add errorWithName constructor for creating Errors with a name.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name

Closes #30 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
